### PR TITLE
Add groupie bots!

### DIFF
--- a/resources/configs/game_settings.json
+++ b/resources/configs/game_settings.json
@@ -5,7 +5,7 @@
         "GROUP_MEMBER_SIZE": 10.0,
         "MINE_SIZE": 40.0,
         "GROUP_SPEED": 140.0,
-        "MINE_RESOURCE_COUNT": 10.0,
+        "MINE_RESOURCE_COUNT": 20.0,
         "GAME_BOUNDS_RADIUS": 600.0,
         "TOTAL_RESOURCE_REQUIREMENTS": 20
     },

--- a/scripts/run_bots.rb
+++ b/scripts/run_bots.rb
@@ -25,7 +25,7 @@ begin
   pids = []
   for _ in 1..num_bots do
     j = fork do
-      exec "./build/src/client/ug-client -x -b -s 0 -a #{server_ip}"
+      exec "./build/src/client/ug-client -x -b -s 2 -a #{server_ip}"
       exit
     end
     pids.push j

--- a/src/common/bots/Bot.hpp
+++ b/src/common/bots/Bot.hpp
@@ -14,15 +14,18 @@
 #include <iostream>
 #include <memory>
 
-enum BotStrategy { Random, NearestGreedy, MostNeededGreedy, Groupie, GreedieGroupie };
+enum BotStrategy { Random, NearestGreedy, Groupie, MostNeededGreedy, GreedieGroupie };
 
 class Bot {
   public:
+    const uint32_t MIN_DISTANCE_TO_TOGGLE_JOINABLE = 15;
     Bot();
     ~Bot(){};
     Bot(const Bot& temp_obj) = delete;
     Bot& operator=(const Bot& temp_obj) = delete;
 
+    std::pair<InputDef::ReliableInput, InputDef::UnreliableInput>
+    getGroupieMove(uint32_t bot_player_id, GameObjectController& goc);
     std::pair<InputDef::ReliableInput, InputDef::UnreliableInput>
     getNearestGreedyMove(uint32_t bot_player_id, GameObjectController& goc);
     std::pair<InputDef::ReliableInput, InputDef::UnreliableInput> getRandomMove();


### PR DESCRIPTION
**Description**

These bots will chase down the closest player in a joinable state. When they aren't chasing down a player to group with, they use the greedy strategy instead. New default for run_bots script.