### PR TITLE
Play in the past

### DIFF
--- a/resources/configs/game_settings.json
+++ b/resources/configs/game_settings.json
@@ -10,14 +10,14 @@
         "TOTAL_RESOURCE_REQUIREMENTS": 20
     },
     "core": {
-        "USE_REMAINDER_DELTA_TIME": false
+        "USE_REMAINDER_DELTA_TIME": true
     },
     "physics": {
         "MIN_TIME_STEP_SEC": 0.008
     },
     "threads": {
         "CLIENT_FETCH_PLAYER_ID_SLEEP": 16,
-        "SERVER_INPUT_WINDOW_SLEEP": 50,
+        "SERVER_INPUT_WINDOW_SLEEP": 16,
         "CLIENT_RELIABLE_SEND_SLEEP": 16,
         "CLIENT_UNRELIABLE_SEND_SLEEP": 16,
         "SERVER_BROADCAST_GAME_STATE_SLEEP": 16,
@@ -32,6 +32,7 @@
     },
     "interpolation": {
         "REPLAY": true,
-        "REPLAY_TICK_DELTA_THRESHOLD": 5
+        "REPLAY_TICK_DELTA_THRESHOLD": 5,
+        "CLIENT_GAME_STATE_BUFFER_SIZE": 3
     }
 }

--- a/resources/configs/game_settings.json
+++ b/resources/configs/game_settings.json
@@ -25,7 +25,7 @@
     },
     "networking": {
         "SERVER_UNRELIABLE_RECV_TIMEOUT_SEC": 1,
-        "SERVER_TCP_PORT": 4845,
+        "SERVER_TCP_PORT": 4844,
         "SERVER_STATE_UDP_PORT": 4845,
         "SERVER_INPUT_UDP_PORT": 4846,
         "LOCALHOST_IP": "127.0.0.1"

--- a/resources/configs/game_settings.json
+++ b/resources/configs/game_settings.json
@@ -9,8 +9,11 @@
         "GAME_BOUNDS_RADIUS": 600.0,
         "TOTAL_RESOURCE_REQUIREMENTS": 20
     },
+    "core": {
+        "USE_REMAINDER_DELTA_TIME": false
+    },
     "physics": {
-        "MIN_TIME_STEP_SEC": 0.016
+        "MIN_TIME_STEP_SEC": 0.008
     },
     "threads": {
         "CLIENT_FETCH_PLAYER_ID_SLEEP": 16,
@@ -22,7 +25,7 @@
     },
     "networking": {
         "SERVER_UNRELIABLE_RECV_TIMEOUT_SEC": 1,
-        "SERVER_TCP_PORT": 4844,
+        "SERVER_TCP_PORT": 4845,
         "SERVER_STATE_UDP_PORT": 4845,
         "SERVER_INPUT_UDP_PORT": 4846,
         "LOCALHOST_IP": "127.0.0.1"

--- a/resources/configs/game_settings.json
+++ b/resources/configs/game_settings.json
@@ -28,11 +28,11 @@
         "SERVER_TCP_PORT": 4844,
         "SERVER_STATE_UDP_PORT": 4845,
         "SERVER_INPUT_UDP_PORT": 4846,
-        "LOCALHOST_IP": "127.0.0.1"
+        "LOCALHOST_IP": "127.0.0.1",
+        "INPUT_TICK_DELTA_THRESHOLD": 25
     },
     "interpolation": {
-        "REPLAY": true,
-        "REPLAY_TICK_DELTA_THRESHOLD": 5,
-        "CLIENT_GAME_STATE_BUFFER_SIZE": 3
+        "CLIENT_GAME_STATE_BUFFER_SIZE": 3,
+        "BEHIND_TICK_DELTA_THRESHOLD": 10
     }
 }

--- a/src/client/rendering/BaseUIElement.hpp
+++ b/src/client/rendering/BaseUIElement.hpp
@@ -30,6 +30,7 @@ struct UIData {
     GameStatus game_status;
     uint32_t winner_player_id;
     uint32_t tick;
+    float tick_duration_ms;
 };
 
 class BaseUIElement {

--- a/src/client/rendering/BaseUIElement.hpp
+++ b/src/client/rendering/BaseUIElement.hpp
@@ -19,8 +19,12 @@
 struct UIData {
     float game_steps_per_second;
     float game_updates_per_second;
-    float network_updates_per_second;
+    float server_state_per_second;
     float tick_delta_average;
+    float behind_game_state_rate;
+    float ahead_game_state_rate;
+    float interpolate_distance_average;
+    float stall_distance_average;
     std::array<uint32_t, RESOURCE_TYPE_COUNT> resources;
     std::array<uint32_t, RESOURCE_TYPE_COUNT> resource_goals;
     GameStatus game_status;

--- a/src/client/rendering/BaseUIElement.hpp
+++ b/src/client/rendering/BaseUIElement.hpp
@@ -23,6 +23,7 @@ struct UIData {
     float tick_delta_average;
     float behind_game_state_rate;
     float ahead_game_state_rate;
+    float no_game_state_rate;
     float interpolate_distance_average;
     float stall_distance_average;
     std::array<uint32_t, RESOURCE_TYPE_COUNT> resources;

--- a/src/client/rendering/DebugUIElement.cpp
+++ b/src/client/rendering/DebugUIElement.cpp
@@ -20,19 +20,25 @@ DebugUIElement::DebugUIElement(sf::Vector2u window_size, sf::Vector2f size,
 
 void DebugUIElement::update(const UIData& ui_data) {
     std::stringstream stream;
-    stream << "FPS:               " << std::fixed << std::setprecision(0)
-           << ui_data.game_steps_per_second << "\n"
-           << "State updates/sec: " << std::fixed << std::setprecision(0)
-           << ui_data.game_updates_per_second << "\n"
-           << "Server states/sec: " << std::fixed << std::setprecision(0)
-           << ui_data.server_state_per_second << "\n"
-           << "Tick delta avg:    " << std::fixed << std::setprecision(1)
-           << ui_data.tick_delta_average << "\n"
-           << "Behind server/sec: " << ui_data.behind_game_state_rate << "\n"
-           << "Ahead server/sec:  " << ui_data.ahead_game_state_rate << "\n"
-           << "Inter dist avg:    " << ui_data.interpolate_distance_average << "\n"
-           << "Stall dist avg:    " << ui_data.stall_distance_average << "\n"
-           << "Tick:              " << ui_data.tick;
+    stream << std::fixed << std::setprecision(0) << std::setw(6) << ui_data.game_steps_per_second
+           << " FPS\n"
+           << std::fixed << std::setprecision(0) << std::setw(6) << ui_data.game_updates_per_second
+           << " State updates/sec\n"
+           << std::fixed << std::setprecision(0) << std::setw(6) << ui_data.server_state_per_second
+           << " Server states/sec\n"
+           << std::setw(6) << std::fixed << std::setprecision(2)
+           << ui_data.behind_game_state_rate / ui_data.game_updates_per_second
+           << " Behind server state\n"
+           << std::setw(6) << std::fixed << std::setprecision(2)
+           << ui_data.ahead_game_state_rate / ui_data.game_updates_per_second
+           << " Ahead server state\n"
+           << std::setw(6) << ui_data.interpolate_distance_average << " Inter dist avg\n"
+           << std::setw(6) << ui_data.stall_distance_average << " Stall dist avg\n"
+           << std::fixed << std::setprecision(1) << std::setw(6) << ui_data.tick_delta_average
+           << " Tick delta avg\n"
+           << std::setw(6) << ui_data.tick << " Tick\n"
+           << std::setw(6) << std::fixed << std::setprecision(0) << ui_data.tick_duration_ms
+           << " Tick duration ms";
     m_text.setString(stream.str());
 
     // Update position according to text size

--- a/src/client/rendering/DebugUIElement.cpp
+++ b/src/client/rendering/DebugUIElement.cpp
@@ -20,13 +20,19 @@ DebugUIElement::DebugUIElement(sf::Vector2u window_size, sf::Vector2f size,
 
 void DebugUIElement::update(const UIData& ui_data) {
     std::stringstream stream;
-    stream << "FPS: " << std::fixed << std::setprecision(0) << ui_data.game_steps_per_second << "\n"
-           << "UPS: " << std::fixed << std::setprecision(0) << ui_data.game_updates_per_second
-           << "\n"
-           << "XPS: " << std::fixed << std::setprecision(0) << ui_data.network_updates_per_second
-           << "\n"
-           << "TDA: " << std::fixed << std::setprecision(0) << ui_data.tick_delta_average << "\n"
-           << "TIK: " << ui_data.tick;
+    stream << "FPS:               " << std::fixed << std::setprecision(0)
+           << ui_data.game_steps_per_second << "\n"
+           << "State updates/sec: " << std::fixed << std::setprecision(0)
+           << ui_data.game_updates_per_second << "\n"
+           << "Server states/sec: " << std::fixed << std::setprecision(0)
+           << ui_data.server_state_per_second << "\n"
+           << "Tick delta avg:    " << std::fixed << std::setprecision(1)
+           << ui_data.tick_delta_average << "\n"
+           << "Behind server/sec: " << ui_data.behind_game_state_rate << "\n"
+           << "Ahead server/sec:  " << ui_data.ahead_game_state_rate << "\n"
+           << "Inter dist avg:    " << ui_data.interpolate_distance_average << "\n"
+           << "Stall dist avg:    " << ui_data.stall_distance_average << "\n"
+           << "Tick:              " << ui_data.tick;
     m_text.setString(stream.str());
 
     // Update position according to text size

--- a/src/client/rendering/DebugUIElement.cpp
+++ b/src/client/rendering/DebugUIElement.cpp
@@ -32,10 +32,12 @@ void DebugUIElement::update(const UIData& ui_data) {
            << std::setw(6) << std::fixed << std::setprecision(2)
            << ui_data.ahead_game_state_rate / ui_data.game_updates_per_second
            << " Ahead server state\n"
+           << std::setw(6) << std::fixed << std::setprecision(2)
+           << ui_data.no_game_state_rate / ui_data.game_updates_per_second << " No server state\n"
            << std::setw(6) << ui_data.interpolate_distance_average << " Inter dist avg\n"
            << std::setw(6) << ui_data.stall_distance_average << " Stall dist avg\n"
            << std::fixed << std::setprecision(1) << std::setw(6) << ui_data.tick_delta_average
-           << " Tick delta avg\n"
+           << " Tick delta avg (abs)\n"
            << std::setw(6) << ui_data.tick << " Tick\n"
            << std::setw(6) << std::fixed << std::setprecision(0) << ui_data.tick_duration_ms
            << " Tick duration ms";

--- a/src/client/systems/ClientGameController.cpp
+++ b/src/client/systems/ClientGameController.cpp
@@ -121,6 +121,7 @@ void ClientGameController::update(const InputDef::PlayerInputs& pi, sf::Int32 de
     m_tickDeltaMetric.update();
     m_behindGameStateMetric.update();
     m_aheadGameStateMetric.update();
+    m_noGameStateMetric.update();
     m_interpolateGameStateMetric.update();
     m_stallGameStateMetric.update();
 }
@@ -133,6 +134,7 @@ void ClientGameController::postUpdate(sf::Int32 update_time) {
         .tick_delta_average = m_tickDeltaMetric.getAverage(),
         .behind_game_state_rate = m_behindGameStateMetric.getRate(sf::seconds(1)),
         .ahead_game_state_rate = m_aheadGameStateMetric.getRate(sf::seconds(1)),
+        .no_game_state_rate = m_noGameStateMetric.getRate(sf::seconds(1)),
         .interpolate_distance_average = m_interpolateGameStateMetric.getAverage(),
         .stall_distance_average = m_stallGameStateMetric.getAverage(),
         .resources = m_gameObjectController->getPlayerResources(m_playerId),
@@ -167,7 +169,7 @@ void ClientGameController::updateGameState(const InputDef::PlayerInputs& pi, sf:
         ahead(client_tick, smallest_server_tick, game_state_buffer);
         m_aheadGameStateMetric.pushCount();
     }
-    m_tickDeltaMetric.pushCount(smallest_server_tick - client_tick);
+    m_tickDeltaMetric.pushCount(std::abs(static_cast<int>(smallest_server_tick - client_tick)));
 }
 
 /**

--- a/src/client/systems/ClientGameController.cpp
+++ b/src/client/systems/ClientGameController.cpp
@@ -1,14 +1,19 @@
+#include <cmath>
 #include <iostream>
 #include <numeric>
 #include <thread>
 
 #include <SFML/Graphics.hpp>
 
+#include "../../common/events/CollisionEvent.hpp"
+#include "../../common/events/EventController.hpp"
 #include "../../common/physics/VectorUtil.hpp"
 #include "../../common/util/InputDef.hpp"
 #include "../../common/util/StateDef.hpp"
 #include "../../common/util/game_settings.hpp"
 #include "ClientGameController.hpp"
+
+const uint MAX_BEHIND_TICK_DELTA = 10;
 
 ClientGameController::ClientGameController(bool is_headless, bool is_bot, BotStrategy strategy,
                                            const std::string& server_ip, uint32_t server_tcp_port,
@@ -74,8 +79,11 @@ void ClientGameController::preUpdate() {
     switch (m_gameStateCore.status) {
         case GameStatus::not_started: {
             // Keep fetching game state to check if game status changed from not_started
-            GameState game_state = m_networkingClient->getLatestGameState();
-            m_gameStateCore = game_state.core;
+            std::map<uint32_t, GameState> game_state_buffer =
+                m_networkingClient->getGameStateBuffer();
+            if (game_state_buffer.size() == GAME_SETTINGS.CLIENT_GAME_STATE_BUFFER_SIZE) {
+                m_gameStateCore = game_state_buffer.begin()->second.core;
+            }
             break;
         }
         case GameStatus::playing: {
@@ -84,8 +92,6 @@ void ClientGameController::preUpdate() {
                 inputs = getBotMove(m_playerId, m_strategy);
             }
             sendInputs(inputs);
-            saveInputs(inputs);
-            rewindAndReplay();
             break;
         }
         case GameStatus::game_over: {
@@ -104,7 +110,7 @@ void ClientGameController::update(const InputDef::PlayerInputs& pi, sf::Int32 de
             break;
         }
         case GameStatus::playing: {
-            computeGameState(pi, delta_ms);
+            updateGameState(pi, delta_ms);
             break;
         }
         case GameStatus::game_over: {
@@ -114,16 +120,23 @@ void ClientGameController::update(const InputDef::PlayerInputs& pi, sf::Int32 de
     }
 
     m_renderingController->update(delta_ms);
-    m_networkUpdateMetric.update();
     m_tickDeltaMetric.update();
+    m_behindGameStateMetric.update();
+    m_aheadGameStateMetric.update();
+    m_interpolateGameStateMetric.update();
+    m_stallGameStateMetric.update();
 }
 
 void ClientGameController::postUpdate(sf::Int32 update_time) {
     UIData ui_data = {
         .game_steps_per_second = m_gameStepMetric.getRate(sf::seconds(1)),
         .game_updates_per_second = m_gameUpdateMetric.getRate(sf::seconds(1)),
-        .network_updates_per_second = m_networkUpdateMetric.getRate(sf::seconds(1)),
+        .server_state_per_second = m_networkingClient->getServerGameStateRate(sf::seconds(1)),
         .tick_delta_average = m_tickDeltaMetric.getAverage(),
+        .behind_game_state_rate = m_behindGameStateMetric.getRate(sf::seconds(1)),
+        .ahead_game_state_rate = m_aheadGameStateMetric.getRate(sf::seconds(1)),
+        .interpolate_distance_average = m_interpolateGameStateMetric.getAverage(),
+        .stall_distance_average = m_stallGameStateMetric.getAverage(),
         .resources = m_gameObjectController->getPlayerResources(m_playerId),
         .resource_goals = m_gameObjectController->getPlayerController()
                               .getPlayer(m_playerId)
@@ -136,69 +149,94 @@ void ClientGameController::postUpdate(sf::Int32 update_time) {
     m_renderingController->postUpdate(update_time, ui_data);
 }
 
-void ClientGameController::rewindAndReplay() {
-    uint32_t m_newGameStateTick = m_networkingClient->getLatestGameStateTick();
-    if (m_newGameStateTick > m_largestAppliedGameStateTick) {
-        GameState game_state = m_networkingClient->getLatestGameState();
-        uint32_t client_tick = getTick();
-        uint32_t server_tick = game_state.core.tick;
-        int tick_delta = client_tick - server_tick;
+void ClientGameController::updateGameState(const InputDef::PlayerInputs& pi, sf::Int32 delta_ms) {
 
-        applyGameState(game_state);
-        if (GAME_SETTINGS.REPLAY) {
-            replay(client_tick, server_tick);
-        }
+    std::map<uint32_t, GameState> game_state_buffer = m_networkingClient->getGameStateBuffer();
 
-        m_largestAppliedGameStateTick = m_newGameStateTick;
-        m_tickDeltaMetric.pushCount(tick_delta);
-        m_networkUpdateMetric.pushCount();
-    } else if (m_newGameStateTick < m_largestAppliedGameStateTick) {
-        std::cout << "Recieved stale game state: " << m_newGameStateTick << "<"
-                  << m_largestAppliedGameStateTick << std::endl;
-    }
-}
-
-void ClientGameController::applyGameState(GameState& game_state) {
-    // Rewind
-    m_gameObjectController->applyGameStateObject(game_state.object);
-    m_gameStateCore = game_state.core;
-    setTick(game_state.core.tick);
-}
-
-void ClientGameController::replay(uint32_t client_tick, uint32_t server_tick) {
-    int tick_delta = client_tick - server_tick;
-
-    if (tick_delta <= 0) {
+    if (game_state_buffer.empty()) {
         return;
     }
 
-    // Prevent the client from drifting too far from server
-    tick_delta = std::min(tick_delta, GAME_SETTINGS.REPLAY_TICK_DELTA_THRESHOLD);
+    uint32_t client_tick = getTick();
+    uint32_t smallest_server_tick = game_state_buffer.begin()->first;
+    const GameState& smallest_server_game_state = game_state_buffer.begin()->second;
 
-    // Loop through ticks that need to be replayed and apply client input from cache if present
-    for (int i = 0; i < tick_delta; ++i) {
-        uint32_t replay_tick = server_tick + i;
-        if (m_tickToInput.count(replay_tick) > 0) {
-            InputDef::ClientInputAndTick client_input_and_tick = m_tickToInput[replay_tick];
-            auto pi = InputDef::PlayerInputs(m_inputController->getPlayerInputs(
-                m_playerId, client_input_and_tick.ri, client_input_and_tick.ui));
-            GameController::computeGameState(pi, GameController::MIN_TIME_STEP);
-        } else {
-            // If we don't have input for this tick pass in empty inputs
-            auto pi = InputDef::PlayerInputs();
-            GameController::computeGameState(pi, GameController::MIN_TIME_STEP);
+    if (client_tick < smallest_server_tick) {
+        behind(client_tick, smallest_server_tick, smallest_server_game_state);
+        m_behindGameStateMetric.pushCount();
+    } else {
+        ahead(client_tick, smallest_server_tick, game_state_buffer);
+        m_aheadGameStateMetric.pushCount();
+    }
+    m_tickDeltaMetric.pushCount(smallest_server_tick - client_tick);
+}
+
+/**
+ * If client is too far behind smallest server game state in the buffer, jump to server
+ * game state, otherwise interpolate the game state of the next tick.
+ */
+void ClientGameController::behind(uint32_t client_tick, uint32_t smallest_server_tick,
+                                  const GameState& smallest_server_game_state) {
+    uint32_t next_tick;
+    if (smallest_server_tick - client_tick > MAX_BEHIND_TICK_DELTA) {
+        next_tick = smallest_server_tick;
+    } else {
+        next_tick = client_tick + 1;
+    }
+    interpolateGameState(client_tick, next_tick, smallest_server_tick, smallest_server_game_state);
+}
+
+/**
+ * If client is ahead of the smallest server game state in the buffer, stay at the same tick but
+ * interpolate to the next available game state in the buffer. If there are none available just keep
+ * the game state the same. Note that the tick stays the same in this case so that we fall back
+ * behind to being behind the smallest server game state in the buffer.
+ */
+void ClientGameController::ahead(uint32_t client_tick, uint32_t smallest_server_tick,
+                                 std::map<uint32_t, GameState>& game_state_buffer) {
+    std::map<uint32_t, GameState>::iterator game_state_buffer_it = game_state_buffer.begin();
+    ++game_state_buffer_it;
+    while (game_state_buffer_it != game_state_buffer.end()) {
+        uint32_t next_server_tick = game_state_buffer_it->first;
+        if (client_tick < next_server_tick) {
+            const GameState& next_server_game_state = game_state_buffer_it->second;
+            uint32_t next_tick = client_tick;
+            // Keep the same tick but interpolate to the next available server game state.
+            interpolateGameState(client_tick - 1, next_tick, next_server_tick,
+                                 next_server_game_state);
+            m_stallGameStateMetric.pushCount(client_tick - smallest_server_tick);
+            return;
         }
+        ++game_state_buffer_it;
     }
 
-    // Remove cached ticks older than the applied server game state's tick. We won't need them for
-    // future replays because we never apply stale game states.
-    for (auto it = m_tickToInput.begin(); it != m_tickToInput.end();) {
-        if (it->first < server_tick) {
-            m_tickToInput.erase(it++);
-        } else {
-            ++it;
-        }
+    // If we reach here then we don't have any game states to interpolate to. Keep the same tick and
+    // game state.
+    m_stallGameStateMetric.pushCount(client_tick - smallest_server_tick);
+    return;
+}
+
+void ClientGameController::interpolateGameState(uint32_t start_tick, uint32_t to_tick,
+                                                uint32_t end_tick, const GameState& game_state) {
+    if (to_tick < start_tick || end_tick < to_tick) {
+        throw std::runtime_error("Can't interpolate to the past.");
     }
+
+    float a = static_cast<float>(to_tick - start_tick) / static_cast<float>(end_tick - start_tick);
+    m_gameStateCore = game_state.core;
+    sf::Int32 delta_ms = MIN_TIME_STEP * (to_tick - start_tick);
+    m_gameObjectController->interpolateGameStateObject(game_state.object, a, delta_ms);
+    applyGameStateEvents(game_state.event);
+    setTick(to_tick);
+    m_interpolateGameStateMetric.pushCount(end_tick - to_tick);
+}
+
+void ClientGameController::applyGameStateEvents(const GameStateEvent& game_state_event) {
+    for (const auto& collision : game_state_event.collisions) {
+        EventController::getInstance().forceQueueEvent(
+            std::move(std::unique_ptr<CollisionEvent>(new CollisionEvent(collision))));
+    }
+    EventController::getInstance().forceProcessEvents();
 }
 
 void ClientGameController::sendInputs(
@@ -209,12 +247,6 @@ void ClientGameController::sendInputs(
     if (!inputs.second.allFalse()) {
         m_networkingClient->pushUnreliableInput(inputs.second);
     }
-}
-
-void ClientGameController::saveInputs(
-    std::pair<InputDef::ReliableInput, InputDef::UnreliableInput> inputs) {
-    m_tickToInput[m_networkingClient->getTick()] =
-        (InputDef::ClientInputAndTick){inputs.second, inputs.first, m_networkingClient->getTick()};
 }
 
 uint32_t ClientGameController::getTick() {

--- a/src/client/systems/ClientGameController.cpp
+++ b/src/client/systems/ClientGameController.cpp
@@ -13,8 +13,6 @@
 #include "../../common/util/game_settings.hpp"
 #include "ClientGameController.hpp"
 
-const uint MAX_BEHIND_TICK_DELTA = 10;
-
 ClientGameController::ClientGameController(bool is_headless, bool is_bot, BotStrategy strategy,
                                            const std::string& server_ip, uint32_t server_tcp_port,
                                            LevelKey level_key) :
@@ -179,8 +177,8 @@ void ClientGameController::updateGameState(const InputDef::PlayerInputs& pi, sf:
 void ClientGameController::behind(uint32_t client_tick, uint32_t smallest_server_tick,
                                   const GameState& smallest_server_game_state) {
     uint32_t next_tick;
-    if (smallest_server_tick - client_tick > MAX_BEHIND_TICK_DELTA) {
-        next_tick = smallest_server_tick;
+    if (smallest_server_tick - client_tick > GAME_SETTINGS.BEHIND_TICK_DELTA_THRESHOLD) {
+        next_tick = smallest_server_tick - GAME_SETTINGS.BEHIND_TICK_DELTA_THRESHOLD;
 
     } else {
         next_tick = client_tick + 1;

--- a/src/client/systems/ClientGameController.hpp
+++ b/src/client/systems/ClientGameController.hpp
@@ -62,6 +62,8 @@ class ClientGameController : public GameController {
 
     /**
      * Interpolate game state from start_tick to to_tick using end_tick's game state.
+     * For example, if start tick is 10, end tick is 20 and to_tick is 11 then we will interpolate
+     * 10% from the local game state to the game state passed in.
      */
     void interpolateGameState(uint32_t start_tick, uint32_t to_tick, uint32_t end_tick,
                               const GameState& game_state);
@@ -98,8 +100,8 @@ class ClientGameController : public GameController {
     sf::RenderWindow m_window;
 
     TemporalMetric m_tickDeltaMetric{
-        4 * 15, sf::seconds(0.25f)}; // Tracks the tick delta between the client and target server
-                                     // state. Each count is a tick delta.
+        4 * 15, sf::seconds(0.25f)}; // Tracks the absolute tick delta between the client and target
+                                     // server state. Each count is a tick delta.
     TemporalMetric m_behindGameStateMetric{
         4 * 15, sf::seconds(0.25f)}; // Tracks of the number of ticks the client is behind the
                                      // target server state. Each count is a tick delta.
@@ -112,6 +114,9 @@ class ClientGameController : public GameController {
     TemporalMetric m_stallGameStateMetric{
         4 * 15, sf::seconds(0.25f)}; // Tracks the number of ticks where the game was stalled and no
                                      // new game state was applied. Each count is a stall.
+    TemporalMetric m_noGameStateMetric{
+        4 * 15, sf::seconds(0.25f)}; // Tracks the number of ticks where there weren't any server
+                                     // game states in the buffer.
 
     std::unique_ptr<NetworkingClient> m_networkingClient;
     std::unique_ptr<InputController> m_inputController;

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(common-lib
     physics/PhysicsController.cpp
     physics/CollisionUtil.cpp
     physics/VectorUtil.cpp
+    physics/PhysicsDef.cpp
     systems/GameObjectStore.cpp
     systems/GroupController.cpp
     systems/PlayerController.cpp

--- a/src/common/events/CollisionEvent.hpp
+++ b/src/common/events/CollisionEvent.hpp
@@ -1,7 +1,7 @@
 #ifndef CollisionEvent_hpp
 #define CollisionEvent_hpp
 
-#include "../physics/PhysicsController.hpp"
+#include "../physics/PhysicsDef.hpp"
 #include "Event.hpp"
 
 class CollisionEvent : public Event {

--- a/src/common/metrics/TemporalMetric.cpp
+++ b/src/common/metrics/TemporalMetric.cpp
@@ -7,7 +7,7 @@ TemporalMetric::TemporalMetric(size_t size, sf::Time time_granularity) :
     m_countSlots(size), m_timeGranularity(time_granularity) {
 }
 
-float TemporalMetric::getRate(sf::Time interval) {
+float TemporalMetric::getRate(sf::Time interval) const {
     sf::Time total_time = static_cast<float>(m_countSlots.size()) * m_timeGranularity;
     if (total_time.asSeconds() == 0 || interval.asSeconds() == 0) {
         return 0;
@@ -20,7 +20,7 @@ float TemporalMetric::getRate(sf::Time interval) {
     return rate;
 }
 
-float TemporalMetric::getAverage() {
+float TemporalMetric::getAverage() const {
     size_t total_count;
     int total_sum;
     std::tie(total_count, total_sum) = accumulateCounts();
@@ -50,7 +50,7 @@ void TemporalMetric::stepSlot() {
     m_currentCounts.clear();
 }
 
-std::pair<size_t, int> TemporalMetric::accumulateCounts() {
+std::pair<size_t, int> TemporalMetric::accumulateCounts() const {
     size_t total_count = 0;
     int total_sum = 0;
     for (auto& count_slot : m_countSlots) {

--- a/src/common/metrics/TemporalMetric.hpp
+++ b/src/common/metrics/TemporalMetric.hpp
@@ -47,12 +47,12 @@ class TemporalMetric {
     /**
      * Get rate of metric per @interval amount of time
      */
-    float getRate(sf::Time interval);
+    float getRate(sf::Time interval) const;
 
     /**
      * Get average value of metric over the entire time span tracked.
      */
-    float getAverage();
+    float getAverage() const;
 
     /**
      * Updates the slot currently accumilating the metric.
@@ -63,7 +63,7 @@ class TemporalMetric {
     /**
      * Returns the count and sum of all the counts.
      */
-    std::pair<size_t, int> accumulateCounts();
+    std::pair<size_t, int> accumulateCounts() const;
 
     sf::Clock m_clock;
     boost::circular_buffer<std::vector<int>> m_countSlots;

--- a/src/common/objects/CircleGameObject.hpp
+++ b/src/common/objects/CircleGameObject.hpp
@@ -38,6 +38,19 @@ class CircleGameObject : public GameObject {
         m_circleRigidBody.setPosition(position);
     };
 
+    void interpolatePosition(const sf::Vector2f position, float a) {
+        m_circleRigidBody.interpolatePosition(position, a);
+    }
+
+    void interpolateVelocity(sf::Vector2f velocity, float a) {
+        m_circleRigidBody.interpolateVelocity(velocity, a);
+    }
+
+    void hermiteInterpolation(sf::Vector2f position, sf::Vector2f velocity, float a,
+                              sf::Int32 delta_ms) {
+        m_circleRigidBody.hermiteInterpolation(position, velocity, a, delta_ms);
+    }
+
     void setCenterPosition(sf::Vector2f position) {
         setPosition({position.x - getRadius(), position.y - getRadius()});
     }

--- a/src/common/objects/CircleGameObject.hpp
+++ b/src/common/objects/CircleGameObject.hpp
@@ -38,17 +38,17 @@ class CircleGameObject : public GameObject {
         m_circleRigidBody.setPosition(position);
     };
 
-    void interpolatePosition(const sf::Vector2f position, float a) {
-        m_circleRigidBody.interpolatePosition(position, a);
+    void linearInterpolatePosition(const sf::Vector2f position, float a) {
+        m_circleRigidBody.linearInterpolatePosition(position, a);
     }
 
     void interpolateVelocity(sf::Vector2f velocity, float a) {
         m_circleRigidBody.interpolateVelocity(velocity, a);
     }
 
-    void hermiteInterpolation(sf::Vector2f position, sf::Vector2f velocity, float a,
-                              sf::Int32 delta_ms) {
-        m_circleRigidBody.hermiteInterpolation(position, velocity, a, delta_ms);
+    void hermiteInterpolatePosition(sf::Vector2f position, sf::Vector2f velocity, float a,
+                                    sf::Int32 delta_ms) {
+        m_circleRigidBody.hermiteInterpolatePosition(position, velocity, a, delta_ms);
     }
 
     void setCenterPosition(sf::Vector2f position) {

--- a/src/common/objects/CircleRigidBody.cpp
+++ b/src/common/objects/CircleRigidBody.cpp
@@ -74,8 +74,8 @@ sf::Vector2f CircleRigidBody::getCenter() const {
     return sf::Vector2f(position.x + radius, position.y + radius);
 }
 
-void CircleRigidBody::hermiteInterpolation(sf::Vector2f position, sf::Vector2f velocity, float a,
-                                           sf::Int32 delta_ms) {
+void CircleRigidBody::hermiteInterpolatePosition(sf::Vector2f position, sf::Vector2f velocity,
+                                                 float a, sf::Int32 delta_ms) {
     float t = a;
     float t2 = t * t;
     float t3 = t2 * t;

--- a/src/common/objects/CircleRigidBody.cpp
+++ b/src/common/objects/CircleRigidBody.cpp
@@ -20,7 +20,7 @@ void CircleRigidBody::applyInput(sf::Vector2f input) {
  * Apply impulse to change velocity based on mass.
  * Formulas taken from http://www.chrishecker.com/Rigid_Body_Dynamics
  */
-void CircleRigidBody::applyImpulse(const PhysicsDef::Impulse& impulse) {
+void CircleRigidBody::applyImpulse(const Impulse& impulse) {
     sf::Vector2f velocity = m_velocity + (impulse.magnitude / m_mass) * impulse.normal;
     setVelocity(velocity);
     setTargetVelocity(velocity);
@@ -72,4 +72,18 @@ sf::Vector2f CircleRigidBody::getCenter() const {
     sf::Vector2f position = getPosition();
     float radius = getRadius();
     return sf::Vector2f(position.x + radius, position.y + radius);
+}
+
+void CircleRigidBody::hermiteInterpolation(sf::Vector2f position, sf::Vector2f velocity, float a,
+                                           sf::Int32 delta_ms) {
+    float t = a;
+    float t2 = t * t;
+    float t3 = t2 * t;
+    m_position = (2.f * t3 - 3.f * t2 + 1.f) * m_position +
+                 (t3 - 2.f * t2 + t) * delta_ms * m_velocity + (-2.f * t3 + 3.f * t2) * position +
+                 (t3 - t2) * delta_ms * velocity;
+    m_velocity =
+        1.f / delta_ms *
+        ((6.f * t2 - 6.f * t) * m_position + (3.f * t2 - 4.f * t + 1.f) * delta_ms * m_velocity +
+         (-6.f * t2 + 6.f * t) * position + (3.f * t2 - 2.f * t) * delta_ms * velocity);
 }

--- a/src/common/objects/CircleRigidBody.hpp
+++ b/src/common/objects/CircleRigidBody.hpp
@@ -39,7 +39,7 @@ class CircleRigidBody : public GameObject {
         m_position = position;
     }
 
-    void interpolatePosition(const sf::Vector2f position, float a) {
+    void linearInterpolatePosition(const sf::Vector2f position, float a) {
         m_position = VectorUtil::lerp(m_position, position, a);
     }
 
@@ -63,8 +63,8 @@ class CircleRigidBody : public GameObject {
 
     void setTargetVelocity(sf::Vector2f target_velocity);
 
-    void hermiteInterpolation(sf::Vector2f position, sf::Vector2f velocity, float a,
-                              sf::Int32 delta_ms);
+    void hermiteInterpolatePosition(sf::Vector2f position, sf::Vector2f velocity, float a,
+                                    sf::Int32 delta_ms);
 
     void applyImpulse(const Impulse& impulse);
 

--- a/src/common/objects/CircleRigidBody.hpp
+++ b/src/common/objects/CircleRigidBody.hpp
@@ -39,6 +39,10 @@ class CircleRigidBody : public GameObject {
         m_position = position;
     }
 
+    void interpolatePosition(const sf::Vector2f position, float a) {
+        m_position = VectorUtil::lerp(m_position, position, a);
+    }
+
     void setCenterPosition(sf::Vector2f position) {
         setPosition({position.x - getRadius(), position.y - getRadius()});
     }
@@ -50,10 +54,20 @@ class CircleRigidBody : public GameObject {
     sf::Vector2f getTargetVelocity() const {
         return m_targetVelocity;
     }
+
     void setVelocity(sf::Vector2f velocity);
+
+    void interpolateVelocity(sf::Vector2f velocity, float a) {
+        m_position = VectorUtil::lerp(m_velocity, velocity, a);
+    }
+
     void setTargetVelocity(sf::Vector2f target_velocity);
 
-    void applyImpulse(const PhysicsDef::Impulse& impulse);
+    void hermiteInterpolation(sf::Vector2f position, sf::Vector2f velocity, float a,
+                              sf::Int32 delta_ms);
+
+    void applyImpulse(const Impulse& impulse);
+
     void applyInput(sf::Vector2f input);
 
     const bool isMovable() const {

--- a/src/common/objects/Group.cpp
+++ b/src/common/objects/Group.cpp
@@ -32,6 +32,12 @@ void Group::applyUpdate(GroupUpdate gu) {
     setRadius(gu.radius);
 }
 
+void Group::applyInterpolatedUpdate(GroupUpdate gu, float a, sf::Int32 delta_ms) {
+    setActive(gu.is_active);
+    hermiteInterpolation({gu.x_pos, gu.y_pos}, gu.velocity, a, delta_ms);
+    setRadius(gu.radius);
+}
+
 void Group::setActive(bool active) {
     CircleGameObject::setActive(active);
 }
@@ -42,7 +48,8 @@ void Group::setDirection(sf::Vector2f direction) {
 
 sf::Packet& operator<<(sf::Packet& packet, const GroupUpdate& group_update) {
     packet << group_update.group_id << group_update.is_active << group_update.x_pos
-           << group_update.y_pos << group_update.radius;
+           << group_update.y_pos << group_update.radius << group_update.velocity.x
+           << group_update.velocity.y;
 
     return packet;
 }
@@ -50,6 +57,10 @@ sf::Packet& operator<<(sf::Packet& packet, const GroupUpdate& group_update) {
 sf::Packet& operator>>(sf::Packet& packet, GroupUpdate& group_update) {
     packet >> group_update.group_id >> group_update.is_active >> group_update.x_pos >>
         group_update.y_pos >> group_update.radius;
+
+    float vel_x, vel_y;
+    packet >> vel_x >> vel_y;
+    group_update.velocity = {vel_x, vel_y};
 
     return packet;
 }

--- a/src/common/objects/Group.cpp
+++ b/src/common/objects/Group.cpp
@@ -34,7 +34,7 @@ void Group::applyUpdate(GroupUpdate gu) {
 
 void Group::applyInterpolatedUpdate(GroupUpdate gu, float a, sf::Int32 delta_ms) {
     setActive(gu.is_active);
-    hermiteInterpolation({gu.x_pos, gu.y_pos}, gu.velocity, a, delta_ms);
+    hermiteInterpolatePosition({gu.x_pos, gu.y_pos}, gu.velocity, a, delta_ms);
     setRadius(gu.radius);
 }
 

--- a/src/common/objects/Group.hpp
+++ b/src/common/objects/Group.hpp
@@ -19,6 +19,7 @@ struct GroupUpdate {
     float y_pos;
     float radius;
     bool joinable;
+    sf::Vector2f velocity;
 };
 
 sf::Packet& operator<<(sf::Packet& packet, const GroupUpdate& group_update);
@@ -36,6 +37,7 @@ class Group : public CircleGameObject {
 
     GroupUpdate getUpdate();
     void applyUpdate(GroupUpdate gu);
+    void applyInterpolatedUpdate(GroupUpdate gu, float a, sf::Int32 delta_ms);
 
   private:
 };

--- a/src/common/physics/CollisionUtil.cpp
+++ b/src/common/physics/CollisionUtil.cpp
@@ -106,14 +106,14 @@ Collision CollisionUtil::getCollision(const CircleRigidBody& circle_a,
     return collision;
 }
 
-std::pair<PhysicsDef::Impulse, PhysicsDef::Impulse>
-CollisionUtil::getImpulses(const CircleRigidBody& circle_a, const CircleRigidBody& circle_b,
-                           const Collision& collision) {
+std::pair<Impulse, Impulse> CollisionUtil::getImpulses(const CircleRigidBody& circle_a,
+                                                       const CircleRigidBody& circle_b,
+                                                       const Collision& collision) {
     sf::Vector2f relative_velocity = circle_a.getVelocity() - circle_b.getVelocity();
     float impulse = -2.f * VectorUtil::dot(relative_velocity, collision.normal) /
                     (1 / circle_a.getMass() + 1 / circle_b.getMass());
-    return std::make_pair((PhysicsDef::Impulse){impulse, collision.normal},
-                          (PhysicsDef::Impulse){impulse, -collision.normal});
+    return std::make_pair((Impulse){impulse, collision.normal},
+                          (Impulse){impulse, -collision.normal});
 }
 
 bool CollisionUtil::isInBounds(const CircleRigidBody& circle, sf::Vector2f bounds_center,

--- a/src/common/physics/CollisionUtil.hpp
+++ b/src/common/physics/CollisionUtil.hpp
@@ -9,21 +9,6 @@
 #include "../objects/CircleRigidBody.hpp"
 #include "PhysicsDef.hpp"
 
-/**
- * Details of collision between two rigid bodies.
- * @ids: ids of the two rigid bodies.
- * @position: point of contact between the rigid bodies after collision is resolved.
- * @normal: normal of the collision from the latter body to the former.
- * @resolution: the amount by which the bodies should be displaced to resolve the collision.
- */
-struct Collision {
-    std::pair<uint32_t, uint32_t> ids;
-    sf::Vector2f position;
-    sf::Vector2f normal;
-    std::pair<sf::Vector2f, sf::Vector2f> resolution;
-    bool collided;
-};
-
 enum Orientation { above, below, left, right, inside };
 
 namespace CollisionUtil {
@@ -66,9 +51,9 @@ namespace CollisionUtil {
      * This impulse assumes a perfect elastic collision.
      * Formulas taken from http://www.chrishecker.com/Rigid_Body_Dynamics
      */
-    std::pair<PhysicsDef::Impulse, PhysicsDef::Impulse> getImpulses(const CircleRigidBody& circle_a,
-                                                                    const CircleRigidBody& circle_b,
-                                                                    const Collision& collision);
+    std::pair<Impulse, Impulse> getImpulses(const CircleRigidBody& circle_a,
+                                            const CircleRigidBody& circle_b,
+                                            const Collision& collision);
 
     /**
      * Returns true if the entire circle is inside the "bounds" circle defined by bounds center and

--- a/src/common/physics/PhysicsController.hpp
+++ b/src/common/physics/PhysicsController.hpp
@@ -13,12 +13,12 @@ class PhysicsController {
     CircleRigidBody& add(std::unique_ptr<CircleRigidBody> circle_rigid_body);
     void update(sf::Int32 delta_ms);
     void step(sf::Int32 delta_ms);
+    void resolveCollisions();
+    void resolveMapBounds();
 
   private:
-    void resolveCollisions();
     void resolveCollision(CircleRigidBody& circle_a, CircleRigidBody& circle_b,
                           const Collision& collision);
-    void resolveMapBounds();
     void fireCollisionEvent(const Collision& collision);
 
     std::vector<std::unique_ptr<CircleRigidBody>> m_circleRigidBodies;

--- a/src/common/physics/PhysicsDef.cpp
+++ b/src/common/physics/PhysicsDef.cpp
@@ -1,0 +1,27 @@
+#include "PhysicsDef.hpp"
+
+sf::Packet& operator<<(sf::Packet& packet, const Collision& collision) {
+    packet << static_cast<sf::Uint32>(collision.ids.first)
+           << static_cast<sf::Uint32>(collision.ids.second) << collision.position.x
+           << collision.position.y << collision.normal.x << collision.normal.y
+           << collision.resolution.first.x << collision.resolution.first.y
+           << collision.resolution.second.x << collision.resolution.second.y << collision.collided;
+    return packet;
+};
+
+sf::Packet& operator>>(sf::Packet& packet, Collision& collision) {
+    sf::Uint32 id_first, id_second;
+    float pos_x, pos_y, nor_x, nor_y, res_first_x, res_second_x, res_first_y, res_second_y;
+    bool collided;
+    packet >> id_first >> id_second >> pos_x >> pos_y >> nor_x >> nor_y >> res_first_x >>
+        res_first_y >> res_second_x >> res_second_y >> collided;
+    collision = {
+        std::make_pair(static_cast<uint32_t>(id_first), static_cast<uint32_t>(id_second)),
+        sf::Vector2f(pos_x, pos_y),
+        sf::Vector2f(nor_x, nor_y),
+        std::make_pair(sf::Vector2f(res_first_x, res_first_y),
+                       sf::Vector2f(res_second_x, res_second_y)),
+        collided,
+    };
+    return packet;
+};

--- a/src/common/physics/PhysicsDef.hpp
+++ b/src/common/physics/PhysicsDef.hpp
@@ -5,15 +5,35 @@
 #include <SFML/Graphics.hpp>
 
 namespace PhysicsDef {
-    struct Impulse {
-        float magnitude;
-        sf::Vector2f normal;
-    };
-    const float IMPULSE_MILTIPLIER = 2.f;
+
+    const float IMPULSE_MILTIPLIER = 3.f;
     const float TRANSITION_SPEED = 20.f; // drag / friction
     const float PLAYER_VELOCITY = GAME_SETTINGS.GROUP_SPEED;
     const float MAX_VELOCITY = PLAYER_VELOCITY * 4.f;
     const float MIN_VELOCITY = -MAX_VELOCITY;
 }; // namespace PhysicsDef
+
+struct Impulse {
+    float magnitude;
+    sf::Vector2f normal;
+};
+
+/*
+ * Details of collision between two rigid bodies.
+ * @ids: ids of the two rigid bodies.
+ * @position: point of contact between the rigid bodies after collision is resolved.
+ * @normal: normal of the collision from the latter body to the former.
+ * @resolution: the amount by which the bodies should be displaced to resolve the collision.
+ */
+struct Collision {
+    std::pair<uint32_t, uint32_t> ids;
+    sf::Vector2f position;
+    sf::Vector2f normal;
+    std::pair<sf::Vector2f, sf::Vector2f> resolution;
+    bool collided;
+};
+
+sf::Packet& operator<<(sf::Packet& packet, const Collision& collision);
+sf::Packet& operator>>(sf::Packet& packet, Collision& collision);
 
 #endif /* PhysicsDef_hpp */

--- a/src/common/physics/PhysicsDef.hpp
+++ b/src/common/physics/PhysicsDef.hpp
@@ -9,8 +9,8 @@ namespace PhysicsDef {
         float magnitude;
         sf::Vector2f normal;
     };
-    const float IMPULSE_MILTIPLIER = 3.f;
-    const float TRANSITION_SPEED = 10.f; // drag / friction
+    const float IMPULSE_MILTIPLIER = 2.f;
+    const float TRANSITION_SPEED = 20.f; // drag / friction
     const float PLAYER_VELOCITY = GAME_SETTINGS.GROUP_SPEED;
     const float MAX_VELOCITY = PLAYER_VELOCITY * 4.f;
     const float MIN_VELOCITY = -MAX_VELOCITY;

--- a/src/common/systems/GameController.cpp
+++ b/src/common/systems/GameController.cpp
@@ -31,7 +31,10 @@ void GameController::step() {
 
     // Take a variable amount of game state steps depending on how long the last frame took
     sf::Int32 frame_time = m_clock.restart().asMilliseconds();
-    m_timeAccumulator += frame_time;
+    if (!GAME_SETTINGS.USE_REMAINDER_DELTA_TIME) {
+        m_timeAccumulator = 0;
+    }
+    m_timeAccumulator = frame_time;
     sf::Int32 update_time = 0;
     while (m_timeAccumulator >= MIN_TIME_STEP) {
         update(pi, MIN_TIME_STEP);

--- a/src/common/systems/GameController.cpp
+++ b/src/common/systems/GameController.cpp
@@ -30,11 +30,10 @@ void GameController::step() {
     InputDef::PlayerInputs pi = getPlayerInputs();
 
     // Take a variable amount of game state steps depending on how long the last frame took
-    sf::Int32 frame_time = m_clock.restart().asMilliseconds();
     if (!GAME_SETTINGS.USE_REMAINDER_DELTA_TIME) {
         m_timeAccumulator = 0;
     }
-    m_timeAccumulator = frame_time;
+    m_timeAccumulator += m_clock.restart().asMilliseconds();
     sf::Int32 update_time = 0;
     while (m_timeAccumulator >= MIN_TIME_STEP) {
         update(pi, MIN_TIME_STEP);

--- a/src/common/systems/GameObjectController.cpp
+++ b/src/common/systems/GameObjectController.cpp
@@ -92,6 +92,21 @@ void GameObjectController::applyGameStateObject(GameStateObject game_state_objec
     m_resourceController.applyUpdate(game_state_object.rcu);
 }
 
+void GameObjectController::interpolateGameStateObject(GameStateObject game_state_object, float a,
+                                                      sf::Int32 delta_ms) {
+    for (auto gu : game_state_object.group_updates) {
+        m_gameObjectStore.getGroup(gu.group_id)->applyInterpolatedUpdate(gu, a, delta_ms);
+    }
+    for (auto mu : game_state_object.mine_updates) {
+        m_gameObjectStore.getMine(mu.mine_id)->applyUpdate(mu);
+    }
+    for (auto pu : game_state_object.player_updates) {
+        m_gameObjectStore.getPlayer(pu.player_id)->applyUpdate(pu);
+    }
+    m_groupController.applyUpdate(game_state_object.gcu);
+    m_resourceController.applyUpdate(game_state_object.rcu);
+}
+
 GameStateObject GameObjectController::getGameStateObject() {
     auto groups = m_gameObjectStore.getGroups();
     auto mines = m_gameObjectStore.getMines();

--- a/src/common/systems/GameObjectController.hpp
+++ b/src/common/systems/GameObjectController.hpp
@@ -23,6 +23,7 @@ class GameObjectController {
     uint32_t createPlayerWithGroup(uint32_t client_id);
     GameStateObject getGameStateObject();
     void applyGameStateObject(GameStateObject game_state_object);
+    void interpolateGameStateObject(GameStateObject game_state_object, float a, sf::Int32 delta_ms);
 
     sf::Vector2f getPlayerPosition(uint32_t player_id);
     std::array<uint32_t, RESOURCE_TYPE_COUNT> getPlayerResources(uint32_t player_id);

--- a/src/common/util/StateDef.cpp
+++ b/src/common/util/StateDef.cpp
@@ -4,23 +4,45 @@
 
 sf::Packet& operator<<(sf::Packet& packet, const GameStateObject& game_state_object) {
     packet << static_cast<sf::Uint32>(game_state_object.group_updates.size());
-    for (const auto group_update : game_state_object.group_updates) {
+    for (const auto& group_update : game_state_object.group_updates) {
         packet << group_update;
     }
 
     packet << static_cast<sf::Uint32>(game_state_object.mine_updates.size());
-    for (const auto mine_update : game_state_object.mine_updates) {
+    for (const auto& mine_update : game_state_object.mine_updates) {
         packet << mine_update;
     }
 
     packet << static_cast<sf::Uint32>(game_state_object.player_updates.size());
-    for (const auto player_update : game_state_object.player_updates) {
+    for (const auto& player_update : game_state_object.player_updates) {
         packet << player_update;
     }
 
     packet << game_state_object.gcu;
     packet << game_state_object.rcu;
 
+    return packet;
+}
+
+sf::Packet& operator<<(sf::Packet& packet, const GameStateEvent& game_state_event) {
+    packet << static_cast<sf::Uint32>(game_state_event.collisions.size());
+    for (const auto& collision : game_state_event.collisions) {
+        packet << collision;
+    }
+    return packet;
+}
+
+sf::Packet& operator>>(sf::Packet& packet, GameStateEvent& game_state_event) {
+    sf::Uint32 collisions_size;
+    std::vector<Collision> collisions;
+    packet >> collisions_size;
+    collisions.reserve(collisions_size);
+    for (int i = 0; i < collisions_size; ++i) {
+        Collision c = {};
+        packet >> c;
+        collisions.push_back(c);
+    }
+    game_state_event = {collisions};
     return packet;
 }
 
@@ -35,6 +57,7 @@ sf::Packet& operator>>(sf::Packet& packet, GameStateObject& game_state_object) {
     ResourceControllerUpdate rcu;
 
     packet >> group_updates_size;
+    group_updates.reserve(group_updates_size);
     for (int i = 0; i < group_updates_size; ++i) {
         GroupUpdate gu = {};
         packet >> gu;
@@ -42,6 +65,7 @@ sf::Packet& operator>>(sf::Packet& packet, GameStateObject& game_state_object) {
     }
 
     packet >> mine_updates_size;
+    mine_updates.reserve(mine_updates_size);
     for (int i = 0; i < mine_updates_size; ++i) {
         MineUpdate mu = {};
         packet >> mu;
@@ -49,6 +73,7 @@ sf::Packet& operator>>(sf::Packet& packet, GameStateObject& game_state_object) {
     }
 
     packet >> player_updates_size;
+    player_updates.reserve(player_updates_size);
     for (int i = 0; i < player_updates_size; ++i) {
         PlayerUpdate pu = {};
         packet >> pu;
@@ -74,10 +99,10 @@ sf::Packet& operator>>(sf::Packet& packet, GameStateCore& game_state_core) {
 }
 
 sf::Packet& operator<<(sf::Packet& packet, const GameState& game_state) {
-    return packet << game_state.object << game_state.core;
+    return packet << game_state.object << game_state.event << game_state.core;
 }
 sf::Packet& operator>>(sf::Packet& packet, GameState& game_state) {
-    return packet >> game_state.object >> game_state.core;
+    return packet >> game_state.object >> game_state.event >> game_state.core;
 }
 
 sf::Packet& operator<<(sf::Packet& packet, const GameStatus& game_status) {

--- a/src/common/util/StateDef.hpp
+++ b/src/common/util/StateDef.hpp
@@ -8,6 +8,7 @@
 
 #include "../objects/Group.hpp"
 #include "../objects/Mine.hpp"
+#include "../physics/PhysicsDef.hpp"
 #include "../systems/GroupController.hpp"
 #include "../systems/ResourceController.hpp"
 #include "game_def.hpp"
@@ -26,6 +27,10 @@ struct GameStateObject {
     ResourceControllerUpdate rcu;
 };
 
+struct GameStateEvent {
+    std::vector<Collision> collisions;
+};
+
 struct GameStateCore {
     uint32_t tick;
     GameStatus status;
@@ -34,6 +39,7 @@ struct GameStateCore {
 
 struct GameState {
     GameStateObject object;
+    GameStateEvent event;
     GameStateCore core;
 };
 
@@ -42,6 +48,9 @@ sf::Packet& operator>>(sf::Packet& packet, GameStatus& game_status);
 
 sf::Packet& operator<<(sf::Packet& packet, const GameStateObject& game_state_object);
 sf::Packet& operator>>(sf::Packet& packet, GameStateObject& game_state_object);
+
+sf::Packet& operator<<(sf::Packet& packet, const GameStateEvent& game_state_event);
+sf::Packet& operator>>(sf::Packet& packet, GameStateEvent& game_state_event);
 
 sf::Packet& operator<<(sf::Packet& packet, const GameStateCore& game_state_core);
 sf::Packet& operator>>(sf::Packet& packet, GameStateCore& game_state_core);

--- a/src/common/util/game_settings.cpp
+++ b/src/common/util/game_settings.cpp
@@ -58,6 +58,8 @@ GameSettings load_game_setting_globals(const std::string& path) {
 
     bool REPLAY = j["interpolation"]["REPLAY"].get<bool>();
     int REPLAY_TICK_DELTA_THRESHOLD = j["interpolation"]["REPLAY_TICK_DELTA_THRESHOLD"].get<int>();
+    uint32_t CLIENT_GAME_STATE_BUFFER_SIZE =
+        j["interpolation"]["CLIENT_GAME_STATE_BUFFER_SIZE"].get<uint32_t>();
 
     GameSettings game_settings = {
         .MAX_PLAYER_COUNT = MAX_PLAYER_COUNT,
@@ -89,6 +91,7 @@ GameSettings load_game_setting_globals(const std::string& path) {
         .LOCALHOST_IP = LOCALHOST_IP,
         .REPLAY = REPLAY,
         .REPLAY_TICK_DELTA_THRESHOLD = REPLAY_TICK_DELTA_THRESHOLD,
+        .CLIENT_GAME_STATE_BUFFER_SIZE = CLIENT_GAME_STATE_BUFFER_SIZE,
     };
     return game_settings;
 };

--- a/src/common/util/game_settings.cpp
+++ b/src/common/util/game_settings.cpp
@@ -26,6 +26,8 @@ GameSettings load_game_setting_globals(const std::string& path) {
 
     float MIN_TIME_STEP_SEC = j["physics"]["MIN_TIME_STEP_SEC"].get<float>();
 
+    bool USE_REMAINDERS_DELTA_TIME = j["core"]["USE_REMAINDER_DELTA_TIME"].get<bool>();
+
     std::chrono::milliseconds CLIENT_FETCH_PLAYER_ID_SLEEP(
         j["threads"]["CLIENT_FETCH_PLAYER_ID_SLEEP"].get<uint32_t>());
     std::chrono::milliseconds SERVER_INPUT_WINDOW_SLEEP(
@@ -69,6 +71,7 @@ GameSettings load_game_setting_globals(const std::string& path) {
         .GAME_SIZE = GAME_SIZE,
         .TOTAL_RESOURCE_REQUIREMENTS = TOTAL_RESOURCE_REQUIREMENTS,
         .MIN_TIME_STEP_SEC = MIN_TIME_STEP_SEC,
+        .USE_REMAINDER_DELTA_TIME = USE_REMAINDERS_DELTA_TIME,
         .CLIENT_FETCH_PLAYER_ID_SLEEP = CLIENT_FETCH_PLAYER_ID_SLEEP,
         .SERVER_INPUT_WINDOW_SLEEP = SERVER_INPUT_WINDOW_SLEEP,
         .CLIENT_RELIABLE_SEND_SLEEP = CLIENT_RELIABLE_SEND_SLEEP,

--- a/src/common/util/game_settings.cpp
+++ b/src/common/util/game_settings.cpp
@@ -55,11 +55,13 @@ GameSettings load_game_setting_globals(const std::string& path) {
     unsigned short SERVER_INPUT_UDP_PORT =
         j["networking"]["SERVER_INPUT_UDP_PORT"].get<unsigned short>();
     std::string LOCALHOST_IP = j["networking"]["LOCALHOST_IP"].get<std::string>();
+    uint32_t INPUT_TICK_DELTA_THRESHOLD =
+        j["networking"]["INPUT_TICK_DELTA_THRESHOLD"].get<uint32_t>();
 
-    bool REPLAY = j["interpolation"]["REPLAY"].get<bool>();
-    int REPLAY_TICK_DELTA_THRESHOLD = j["interpolation"]["REPLAY_TICK_DELTA_THRESHOLD"].get<int>();
     uint32_t CLIENT_GAME_STATE_BUFFER_SIZE =
         j["interpolation"]["CLIENT_GAME_STATE_BUFFER_SIZE"].get<uint32_t>();
+    uint32_t BEHIND_TICK_DELTA_THRESHOLD =
+        j["interpolation"]["BEHIND_TICK_DELTA_THRESHOLD"].get<uint32_t>();
 
     GameSettings game_settings = {
         .MAX_PLAYER_COUNT = MAX_PLAYER_COUNT,
@@ -89,9 +91,9 @@ GameSettings load_game_setting_globals(const std::string& path) {
         .SERVER_STATE_UDP_PORT = SERVER_STATE_UDP_PORT,
         .SERVER_INPUT_UDP_PORT = SERVER_INPUT_UDP_PORT,
         .LOCALHOST_IP = LOCALHOST_IP,
-        .REPLAY = REPLAY,
-        .REPLAY_TICK_DELTA_THRESHOLD = REPLAY_TICK_DELTA_THRESHOLD,
+        .INPUT_TICK_DELTA_THRESHOLD = INPUT_TICK_DELTA_THRESHOLD,
         .CLIENT_GAME_STATE_BUFFER_SIZE = CLIENT_GAME_STATE_BUFFER_SIZE,
+        .BEHIND_TICK_DELTA_THRESHOLD = BEHIND_TICK_DELTA_THRESHOLD,
     };
     return game_settings;
 };

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -50,6 +50,7 @@ struct GameSettings {
     std::string LOCALHOST_IP;
     bool REPLAY;
     int REPLAY_TICK_DELTA_THRESHOLD;
+    uint32_t CLIENT_GAME_STATE_BUFFER_SIZE;
 };
 
 extern const GameSettings GAME_SETTINGS;

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -32,6 +32,7 @@ struct GameSettings {
     sf::Vector2f GAME_SIZE;
     uint32_t TOTAL_RESOURCE_REQUIREMENTS;
     float MIN_TIME_STEP_SEC;
+    bool USE_REMAINDER_DELTA_TIME;
     std::chrono::milliseconds CLIENT_FETCH_PLAYER_ID_SLEEP;
     std::chrono::milliseconds SERVER_INPUT_WINDOW_SLEEP;
     std::chrono::milliseconds CLIENT_RELIABLE_SEND_SLEEP;

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -48,9 +48,9 @@ struct GameSettings {
     unsigned short SERVER_STATE_UDP_PORT;
     unsigned short SERVER_INPUT_UDP_PORT;
     std::string LOCALHOST_IP;
-    bool REPLAY;
-    int REPLAY_TICK_DELTA_THRESHOLD;
+    uint32_t INPUT_TICK_DELTA_THRESHOLD;
     uint32_t CLIENT_GAME_STATE_BUFFER_SIZE;
+    uint32_t BEHIND_TICK_DELTA_THRESHOLD;
 };
 
 extern const GameSettings GAME_SETTINGS;

--- a/src/server/systems/NetworkingServer.cpp
+++ b/src/server/systems/NetworkingServer.cpp
@@ -221,7 +221,7 @@ void NetworkingServer::setClientUnreliableUpdate(sf::Packet packet, int client_i
     uint32_t drift = std::abs(static_cast<int>((m_tick_ta - client_tick)));
 
     updateDriftMetric(player_id, drift);
-    if (drift < CMD_DRIFT_THRESHOLD) {
+    if (drift < GAME_SETTINGS.INPUT_TICK_DELTA_THRESHOLD) {
         updateUpdatesMetric(player_id);
 
         InputDef::UnreliableInput unreliable_input;

--- a/src/server/systems/NetworkingServer.cpp
+++ b/src/server/systems/NetworkingServer.cpp
@@ -233,6 +233,8 @@ void NetworkingServer::setClientUnreliableUpdate(sf::Packet packet, int client_i
                 m_playerUnreliableUpdates_lock);
             m_playerUnreliableUpdates_t.push_back(player_unreliable_input);
         }
+    } else {
+        std::cerr << "Player input drift too high" << std::endl;
     }
 }
 

--- a/src/server/systems/NetworkingServer.hpp
+++ b/src/server/systems/NetworkingServer.hpp
@@ -23,8 +23,6 @@
 #include "../../common/util/StateDef.hpp"
 
 class NetworkingServer {
-    const uint32_t CMD_DRIFT_THRESHOLD = 1000000;
-
   public:
     NetworkingServer(uint32_t tcp_port);
     ~NetworkingServer();

--- a/src/server/systems/NetworkingServer.hpp
+++ b/src/server/systems/NetworkingServer.hpp
@@ -23,7 +23,7 @@
 #include "../../common/util/StateDef.hpp"
 
 class NetworkingServer {
-    const uint32_t CMD_DRIFT_THRESHOLD = 7;
+    const uint32_t CMD_DRIFT_THRESHOLD = 1000000;
 
   public:
     NetworkingServer(uint32_t tcp_port);

--- a/src/server/systems/ServerGameController.hpp
+++ b/src/server/systems/ServerGameController.hpp
@@ -7,9 +7,11 @@
 #include <vector>
 
 #include "../../common/events/Event.hpp"
+#include "../../common/events/EventController.hpp"
 #include "../../common/systems/GameController.hpp"
 #include "../../common/systems/LevelController.hpp"
 #include "../rendering/TerminalRenderingController.hpp"
+#include "../../common/events/CollisionEvent.hpp"
 
 #include "NetworkingServer.hpp"
 
@@ -20,6 +22,7 @@ class ServerGameController : public GameController {
     ~ServerGameController();
 
     void start() override;
+    void handleCollisionEvent(std::shared_ptr<Event> event);
 
   private:
     // Overrides
@@ -32,10 +35,12 @@ class ServerGameController : public GameController {
 
     // Methods
     void setNetworkState();
+    void addEventListeners();
 
     // Variables
     std::unique_ptr<NetworkingServer> m_networkingServer;
     TerminalRenderingController m_terminalRenderingController;
+    GameStateEvent m_gameStateEvent;
 };
 
 #endif /* ServerGameController_hpp */


### PR DESCRIPTION
**Description**

With the server running on the remote server and the client connected to the ethernet with a ping of ~15ms the experience is fairly smooth. Changing direction isn't instant but the transition is smooth. The group still jitters (even when moving in the same direction) but it's very local, doesn't jump back and forth too far.

_ethernet ping and debug metrics_
<img width="393" alt="Screen Shot 2020-05-23 at 1 22 26 PM" src="https://user-images.githubusercontent.com/3184499/82739916-b3c3d680-9cf8-11ea-9d11-55c6f55ba498.png">

The game is also fairly smooth over wifi and consistent ~18ms ping 

_wifi ping and debug metrics_
<img width="336" alt="Screen Shot 2020-05-23 at 2 39 50 PM" src="https://user-images.githubusercontent.com/3184499/82741050-40739200-9d03-11ea-8c69-089b81535701.png">


Changes:
- Replace rewind and replay with the client playing in the past and
interpolating to game states recieved from the server stored in a fixed
size buffer. The size of the buffer is configurable through the var
CLIENT_GAME_STATE_BUFFER_SIZE in game_settings.json.
- The logic for updating the local game state is as follows:
  - If the clients tick is too far behind (more than
  MAX_BEHIND_TICK_DELTA ticks) the smallest server state in the buffer
  then the local state is overwritten with the smallest server state.
  - If the client tick is not too far behind the smallest server state
  then then a game state is interpolated for the next tick using the
  smallest server state.
  - If the client is ahead of the smallest server state then the next
  game state in the buffer is used to recalculate the current tick's
  state but the tick is not incremented. This is in order to stall and
  fall back behind the smallest server state. If there aren't any states
  in the buffer ahead of the current tick, then the game state doesn't
  change.
- Add debug metrics around interpolation, ahead, behind, etc and update
the layout to be more readable
- Implement hermite interpolation to be able interpolate curves rather
than straight lines given start and end velocity of the rigid bodies.
- Send collision events in game state updates. This was necessary
because we no longer extrapolate, we only interpolate, which means we no
longer run the physics simulation locally and can't trigger visuals
caused by collisions. The events recieved from the server are now
applied and trigger collision animations. This introduced a visual bug
(issue #214).
- Reduce server input window sleep to 16ms to make the client and server
ticks/sec in sync. This is a messy dependency, it just so happens that
the server sleeps for that window causing it to control it's steps per
second. Not really a good way to control tick speed and the client and
server tick speeds goes out of sync as more clients connect. We might
need to implement some clock sync in the future.
- Seems like this change also broke the winner being displayed on the
client (issue #215).
- Minor code cleanup.

**Fixes**

Fixes #X

